### PR TITLE
Disable the word wrap in the pre component and let my code block bre…

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -55,7 +55,7 @@ const InlineCode = styled.code`
     background-color: ${props.theme.colors.greys[0]};
     color: ${props.theme.colors.black};
     font-family: ${props.theme.fonts.monospace.join()};
-    font-size: ${props.theme.fontSizes[0]};
+    font-size: ${props.theme.fontSizes[1]}px;
   `}
 `;
 

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -2,11 +2,19 @@ import React from "react";
 import Highlight, { defaultProps, Language } from "prism-react-renderer";
 import theme from "prism-react-renderer/themes/nightOwl";
 import Pre from "./Pre";
+import styled from "styled-components";
 
 interface CodeBlockProps {
   children: React.ReactNode;
   className?: string;
 }
+
+const ExpanderDiv = styled.div`
+  @media (min-width: 1024px) {
+    margin-left: -80px;
+    margin-right: -80px;
+  }
+`;
 
 const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
   const language = className?.replace(/language-/, "");
@@ -24,48 +32,29 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
         getLineProps,
         getTokenProps
       }): React.ReactNode => (
-        <Pre className={className} style={{ ...style, padding: "20px" }}>
-          {tokens.map((line, i) => (
-            <div key={i} {...getLineProps({ line, key: i })}>
-              {line.map((token, key) => (
-                <span key={key} {...getTokenProps({ token, key })} />
+        <ExpanderDiv>
+          <Pre className={className} style={{ ...style, padding: "20px" }}>
+            <code>
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line, key: i })}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token, key })} />
+                  ))}
+                </div>
               ))}
-            </div>
-          ))}
-        </Pre>
+            </code>
+          </Pre>
+        </ExpanderDiv>
       )}
     </Highlight>
   );
 };
 
-const InlineCode: React.FC<CodeBlockProps> = ({ children, className }) => {
-  const language = className?.replace(/language-/, "");
-  return (
-    <Highlight
-      {...defaultProps}
-      code={children as string}
-      language={language as Language}
-      theme={theme}
-    >
-      {({
-        className,
-        style,
-        tokens,
-        getLineProps,
-        getTokenProps
-      }): React.ReactNode => (
-        <code className={className} style={style}>
-          {tokens.map((line, i) => (
-            <div key={i} {...getLineProps({ line, key: i })}>
-              {line.map((token, key) => (
-                <span key={key} {...getTokenProps({ token, key })} />
-              ))}
-            </div>
-          ))}
-        </code>
-      )}
-    </Highlight>
-  );
-};
+const InlineCode = styled.code`
+  background-color: #eee;
+  color: #000;
+  font-family: ${(props): string => props.theme.fonts.monospace.join()};
+  font-size: ${(props): string => props.theme.fontSizes[0]};
+`;
 
 export { CodeBlock, InlineCode };

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -51,10 +51,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
 };
 
 const InlineCode = styled.code`
-  background-color: #eee;
-  color: #000;
-  font-family: ${(props): string => props.theme.fonts.monospace.join()};
-  font-size: ${(props): string => props.theme.fontSizes[0]};
+  ${(props): string => `
+    background-color: ${props.theme.colors.greys[0]};
+    color: ${props.theme.colors.black};
+    font-family: ${props.theme.fonts.monospace.join()};
+    font-size: ${props.theme.fontSizes[0]};
+  `}
 `;
 
 export { CodeBlock, InlineCode };

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Box, BoxProps } from "rebass/styled-components";
 import styled from "styled-components";
 
 const Layout: React.FC<BoxProps> = styled(Box)`
-  max-width: 700px;
+  max-width: 800px;
   margin: 0 auto;
   padding-left: 16px;
   padding-right: 16px;

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -4,7 +4,6 @@ import P from "./Paragraph";
 import styled from "styled-components";
 import { UnorderedList, OrderedList, ListItem } from "./ListComponents";
 import { CodeBlock, InlineCode } from "./CodeBlock";
-import Pre from "./Pre";
 
 const MarkdownLink = styled(Link)`
   color: ${(props): string => props.theme.colors.textLink};
@@ -29,7 +28,6 @@ export default {
   ul: UnorderedList,
   ol: OrderedList,
   li: ListItem,
-  pre: Pre,
   code: CodeBlock,
   inlineCode: InlineCode,
   hr: StyledHr

--- a/components/Pre.tsx
+++ b/components/Pre.tsx
@@ -4,18 +4,16 @@ import styled from "styled-components";
 export default styled(Box).attrs({
   as: "pre",
   p: 3,
-  mb: 3,
-  fontSize: "15px"
+  mb: 3
 })`
   display: block;
   white-space: pre;
-  white-space: pre-wrap;
-  word-break: break-all;
-  word-wrap: break-word;
   border-radius: 3px;
   text-align: left;
   margin: 1em 0;
   padding: 0.5em;
   line-height: 1.3;
   font-family: ${(props): string => props.theme.fonts.monospace.join()};
+  font-size: ${(props): string => props.theme.fontSizes[0]};
+  overflow: auto;
 `;

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -32,8 +32,3 @@ and NLP fields.
 ### Workflow Tools 
 - Text Editor: VS Code, IntelliJ IDEA 
 - Source Control: Git 
-
-
-
-
-


### PR DESCRIPTION
Disable the word wrap in the pre component and let my code block breathe a little on larger screens.

the inline code component does not need highlighting etc, just remove all of that!